### PR TITLE
scylla-bench: listen for close signals

### DIFF
--- a/modes.go
+++ b/modes.go
@@ -259,7 +259,7 @@ func RunTest(resultChannel chan Result, workload WorkloadGenerator, rateLimiter 
 	start := time.Now()
 	partialStart := start
 	iter := NewTestIterator(workload)
-	for !iter.IsDone() {
+	for !iter.IsDone() && atomic.LoadUint32(&stopAll) == 0 {
 		rateLimiter.Wait()
 
 		err, latency := test(rb)


### PR DESCRIPTION
Currently scylla-bench captures SIGTERM signals and flips stopAll to 1.
Without checking its value in the loop, scylla-bench won't terminate on
CTRL+C.