### PR TITLE
Kill scylla-bench on the second CTRL+C

### DIFF
--- a/main.go
+++ b/main.go
@@ -380,6 +380,10 @@ func main() {
 		<-interrupted
 		fmt.Println("\ninterrupted")
 		atomic.StoreUint32(&stopAll, 1)
+
+		<-interrupted
+		fmt.Println("\nkilled")
+		os.Exit(1)
 	}()
 
 	if testDuration > 0 {


### PR DESCRIPTION
Currently, on CTRL+C, scylla-bench will flip a stop flag and then will
wait for all ongoing request to finish, while not sending any new ones,
before stopping.
In some cases the user might wish to not stop the measurement
gracefully, instead they want scylla-bench to stop immediately.
To support this use-case, when the user sends a second interrupt
(CTRL+C) stop the process immediately.