### PR TITLE
Fix batch creation to match new gocql

### DIFF
--- a/modes.go
+++ b/modes.go
@@ -438,7 +438,7 @@ func DoBatchedWrites(session *gocql.Session, resultChannel chan Result, workload
 	request := fmt.Sprintf("INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?)", keyspaceName, tableName)
 
 	RunTest(resultChannel, workload, rateLimiter, func(rb *ResultBuilder) (error, time.Duration) {
-		batch := gocql.NewBatch(gocql.UnloggedBatch)
+		batch := session.NewBatch(gocql.UnloggedBatch)
 		batchSize := 0
 
 		currentPk := workload.NextPartitionKey()


### PR DESCRIPTION
`gocql.NewBatch` is now deprecated (and broken)
switching to use `session.NewBatch`

Fixes: #31