### PR TITLE
Add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Note that this option should be set for both write and read (counter_update and 
 * `table` defines table name to work with
 * `username` - cql username for authentication
 * `password` - cql password for authentication
+* `tls` - use TLS encryption
 
 ### Random value distributions
 

--- a/main.go
+++ b/main.go
@@ -217,6 +217,8 @@ func main() {
 		distribution string
 
 		hostSelectionPolicy string
+
+		tls bool
 	)
 
 	flag.StringVar(&mode, "mode", "", "operating mode: write, read, counter_update, counter_read, scan")
@@ -259,6 +261,8 @@ func main() {
 	flag.StringVar(&tableName, "table", "test", "table to use")
 	flag.StringVar(&username, "username", "", "cql username for authentication")
 	flag.StringVar(&password, "password", "", "cql password for authentication")
+
+	flag.BoolVar(&tls, "tls", false, "use TLS encryption")
 
 	flag.StringVar(&hostSelectionPolicy, "host-selection-policy", "token-aware", "set the driver host selection policy (round-robin,token-aware,dc-aware),default 'token-aware'")
 
@@ -327,6 +331,9 @@ func main() {
 	cluster.NumConns = connectionCount
 	cluster.PageSize = pageSize
 	cluster.Timeout = timeout
+	if tls {
+		cluster.SslOpts = &gocql.SslOptions{}
+	}
 	policy, err := newHostSelectionPolicy(hostSelectionPolicy, strings.Split(nodes, ","))
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ type DistributionValue struct {
 	Dist *random.Distribution
 }
 
-func MakeDistributionValue (dist *random.Distribution, defaultDist random.Distribution) *DistributionValue {
+func MakeDistributionValue(dist *random.Distribution, defaultDist random.Distribution) *DistributionValue {
 	*dist = defaultDist
 	return &DistributionValue{dist}
 }
@@ -65,9 +65,9 @@ var (
 
 	testDuration time.Duration
 
-	partitionCount         int64
-	clusteringRowCount     int64
-	clusteringRowSizeDist  random.Distribution
+	partitionCount        int64
+	clusteringRowCount    int64
+	clusteringRowSizeDist random.Distribution
 
 	rowsPerRequest    int
 	provideUpperBound bool
@@ -76,7 +76,7 @@ var (
 
 	rangeCount int
 
-	timeout time.Duration
+	timeout    time.Duration
 	iterations uint
 
 	startTime time.Time


### PR DESCRIPTION
Adds a `-tls` option which enables TLS encryption when specified.

Refs: #37 