### PR TITLE
Print time and latency with reasonable precision

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,9 +88,37 @@ var (
 )
 
 const (
-	withLatencyLineFmt    = "\n%-15v  %15v  %7v  %7v  %-15v  %-15v  %-15v  %-15v  %-15v  %-15v  %-15v  %v"
-	withoutLatencyLineFmt = "\n%-15v  %15v  %7v  %7v"
+	withLatencyLineFmt    = "\n%5v %7v %7v %6v %-6v %-6v %-6v %-6v %-6v %-6v %-6v %v"
+	withoutLatencyLineFmt = "\n%5v %7v %7v %6v"
 )
+
+// time.Duration objects are printed using time.Duration.String(), and that
+// has hardcoded logic on the precision of its output, which is usually
+// excessive. For example, durations more than a second are printed with
+// 9 digits after the decimal point, and duration between 1ms and 1s
+// are printed as ms with 6 digits after the decimal point.
+// The Round function here rounds the duration in a way that printing it
+// will result in up to "digits" digits after the decimal point.
+func Round(d time.Duration) time.Duration {
+	switch {
+	case d < time.Microsecond:
+		// Nanoseconds, no additional digits of precision
+		d = d.Round(time.Nanosecond)
+	case d < time.Millisecond:
+		// Microseconds, no additional digits of precision
+		d = d.Round(time.Microsecond)
+	case d < time.Millisecond * time.Duration(10):
+		// 1-10 milliseconds, show an additional digit of precision
+		d = d.Round(time.Millisecond / time.Duration(10))
+	case d < time.Second:
+		// 10ms-1sec, show integer number of milliseconds.
+		d = d.Round(time.Millisecond)
+	default:
+		// >1sec, show one additional digit of precision.
+		d = d.Round(time.Second / time.Duration(10))
+	}
+	return d
+}
 
 func Query(session *gocql.Session, request string) {
 	err := session.Query(request).Exec()
@@ -182,13 +210,13 @@ func PrintPartialResult(result *MergedResult) {
 		latencyError = "latency measurement error"
 	}
 	if measureLatency {
-		fmt.Printf(withLatencyLineFmt, result.Time, result.Operations, result.ClusteringRows, result.Errors,
-			time.Duration(result.Latency.Max()), time.Duration(result.Latency.ValueAtQuantile(99.9)), time.Duration(result.Latency.ValueAtQuantile(99)),
-			time.Duration(result.Latency.ValueAtQuantile(95)), time.Duration(result.Latency.ValueAtQuantile(90)),
-			time.Duration(result.Latency.ValueAtQuantile(50)), time.Duration(result.Latency.Mean()),
+		fmt.Printf(withLatencyLineFmt, Round(result.Time), result.Operations, result.ClusteringRows, result.Errors,
+			Round(time.Duration(result.Latency.Max())), Round(time.Duration(result.Latency.ValueAtQuantile(99.9))), Round(time.Duration(result.Latency.ValueAtQuantile(99))),
+			Round(time.Duration(result.Latency.ValueAtQuantile(95))), Round(time.Duration(result.Latency.ValueAtQuantile(90))),
+			Round(time.Duration(result.Latency.ValueAtQuantile(50))), Round(time.Duration(result.Latency.Mean())),
 			latencyError)
 	} else {
-		fmt.Printf(withoutLatencyLineFmt, result.Time, result.Operations, result.ClusteringRows, result.Errors)
+		fmt.Printf(withoutLatencyLineFmt, Round(result.Time), result.Operations, result.ClusteringRows, result.Errors)
 	}
 }
 
@@ -438,9 +466,9 @@ func main() {
 	}
 
 	if measureLatency {
-		fmt.Printf(withLatencyLineFmt, "time", "operations/s", "rows/s", "errors", "max", "99.9th", "99th", "95th", "90th", "median", "mean", "")
+		fmt.Printf(withLatencyLineFmt, "time", "ops/s", "rows/s", "errors", "max", "99.9th", "99th", "95th", "90th", "median", "mean", "")
 	} else {
-		fmt.Printf(withoutLatencyLineFmt, "time", "operations/s", "rows/s", "errors")
+		fmt.Printf(withoutLatencyLineFmt, "time", "ops/s", "rows/s", "errors")
 	}
 
 	result := RunConcurrently(maximumRate, func(i int, resultChannel chan Result, rateLimiter RateLimiter) {


### PR DESCRIPTION
When the current code prints times and latencies, it uses the default way
of printing a time.Duration, which prints absurdly precise numbers, and
the following example output shows:

```
 time                operations/s   rows/s   errors  max              99.9th           99th             95th             90th             median           mean
 9.006293118s               26534    26534        0  3.047423ms       1.966079ms       1.179647ms       917.503µs        819.199µs        589.823µs        602.173µs
```

The very long lines are inconvenient to view, and also not helpful
(nobody needs to print whole seconds in nanosecond (!) precision, or
to add 3 more digits of precision to 589 microseconds).

This patch adds a function to Round() time.Duration objects for printing,
and uses it. The result is now more useful, clearer, and easily fits
in a window with a line width of 80:

```
 time   ops/s  rows/s errors max    99.9th 99th   95th   90th   median mean
   1s   27517   27517      0 2.7ms  1.7ms  1.1ms  885µs  786µs  590µs  581µs
```

Fixes #44

Signed-off-by: Nadav Har'El <nyh@scylladb.com>