### PR TITLE
Fix latency recording logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,10 @@ var (
 	timeout    time.Duration
 	iterations uint
 
+	// Any error response that comes with delay greater than errorToTimeoutCutoffTime
+	// to be considered as timeout error and recorded to histogram as such
+	errorToTimeoutCutoffTime    time.Duration
+
 	startTime time.Time
 
 	stopAll uint32
@@ -316,6 +320,12 @@ func main() {
 	}
 	if workload == "timeseries" && mode == "write" && maximumRate == 0 {
 		log.Fatal("max-rate must be provided for time series write loads")
+	}
+
+	if timeout != 0 {
+		errorToTimeoutCutoffTime = timeout / 5
+	} else {
+		errorToTimeoutCutoffTime = time.Second
 	}
 
 	cluster := gocql.NewCluster(strings.Split(nodes, ",")...)

--- a/main.go
+++ b/main.go
@@ -521,7 +521,7 @@ func newHostSelectionPolicy(policy string, hosts []string) (gocql.HostSelectionP
 func setResultsConfiguration() {
 	results.SetGlobalHistogramConfiguration(
 		time.Microsecond.Nanoseconds()*50,
-		(timeout + timeout*2).Nanoseconds(),
+		(timeout*3).Nanoseconds(),
 		3,
 	)
 	results.SetGlobalMeasureLatency(measureLatency)

--- a/modes.go
+++ b/modes.go
@@ -118,19 +118,22 @@ func RunTest(threadResult *results.TestThreadResult, workload WorkloadGenerator,
 	for !iter.IsDone() {
 		rateLimiter.Wait()
 
-		start := rateLimiter.Expected()
-		if start.IsZero() {
-			start = time.Now()
+		expectedStartTime := rateLimiter.Expected()
+		if expectedStartTime.IsZero() {
+			expectedStartTime = time.Now()
 		}
 
-		err, _ := test(threadResult)
+		err, rawLatency := test(threadResult)
 		if err != nil {
-			log.Print(err)
 			threadResult.IncErrors()
-			continue
+			log.Print(err)
+			if rawLatency > errorToTimeoutCutoffTime {
+				// Consider this error to be timeout error and register it in histogram
+				threadResult.RecordLatency(start, time.Now())
+			}
+		} else {
+			threadResult.RecordLatency(start, time.Now())
 		}
-
-		threadResult.RecordLatency(start, time.Now())
 
 		now := time.Now()
 		if now.Sub(partialStart) > time.Second {

--- a/modes.go
+++ b/modes.go
@@ -124,15 +124,16 @@ func RunTest(threadResult *results.TestThreadResult, workload WorkloadGenerator,
 		}
 
 		err, rawLatency := test(threadResult)
+		endTime := time.Now()
 		if err != nil {
 			threadResult.IncErrors()
 			log.Print(err)
 			if rawLatency > errorToTimeoutCutoffTime {
 				// Consider this error to be timeout error and register it in histogram
-				threadResult.RecordLatency(start, time.Now())
+				threadResult.RecordLatency(expectedStartTime, endTime)
 			}
 		} else {
-			threadResult.RecordLatency(start, time.Now())
+			threadResult.RecordLatency(expectedStartTime, endTime)
 		}
 
 		now := time.Now()

--- a/pkg/results/thread_result.go
+++ b/pkg/results/thread_result.go
@@ -50,12 +50,17 @@ func (r *TestThreadResult) ResetPartialResult() {
 }
 
 func (r *TestThreadResult) RecordLatency(start time.Time, end time.Time) {
-	value := end.Sub(start)
+	latency := end.Sub(start).Nanoseconds()
+
+	if latency >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
+		latency = globalResultConfiguration.latencyHistogramConfiguration.maxValue
+	}
+
 	if r.FullResult.Latency != nil {
-		_ = r.FullResult.Latency.RecordValue(value.Nanoseconds())
+		_ = r.FullResult.Latency.RecordValue(latency)
 	}
 	if r.PartialResult.Latency != nil {
-		_ = r.PartialResult.Latency.RecordValue(value.Nanoseconds())
+		_ = r.PartialResult.Latency.RecordValue(latency)
 	}
 }
 


### PR DESCRIPTION
it is based on https://github.com/scylladb/scylla-bench/pull/51

 main.go and modes.go: fix latency registration logic
      Fix is needed due to the couple of issues, one of which is #50
      Another issue is that we do not destinct timeout error from other errors
      s-b did not report any latency if error occured, which is not correct in case of timeout errors.
      Since timeout errors can come from gocql and from the coordinator
      it was decided to distinct errors on timeout and non-timeout errors
      relaying on time it took for the workload to get an error
    
      Another change was not to interpolate latencies to avoid data spoiling, but store raw value instead
