### PR TITLE
main.go,  modes.go: move test results part out of the main package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.idea

--- a/pkg/results/auxiliary.go
+++ b/pkg/results/auxiliary.go
@@ -1,0 +1,31 @@
+package results
+
+import "time"
+
+// time.Duration objects are printed using time.Duration.String(), and that
+// has hardcoded logic on the precision of its output, which is usually
+// excessive. For example, durations more than a second are printed with
+// 9 digits after the decimal point, and duration between 1ms and 1s
+// are printed as ms with 6 digits after the decimal point.
+// The Round function here rounds the duration in a way that printing it
+// will result in up to "digits" digits after the decimal point.
+func Round(d time.Duration) time.Duration {
+	switch {
+	case d < time.Microsecond:
+		// Nanoseconds, no additional digits of precision
+		d = d.Round(time.Nanosecond)
+	case d < time.Millisecond:
+		// Microseconds, no additional digits of precision
+		d = d.Round(time.Microsecond)
+	case d < time.Millisecond*time.Duration(10):
+		// 1-10 milliseconds, show an additional digit of precision
+		d = d.Round(time.Millisecond / time.Duration(10))
+	case d < time.Second:
+		// 10ms-1sec, show integer number of milliseconds.
+		d = d.Round(time.Millisecond)
+	default:
+		// >1sec, show one additional digit of precision.
+		d = d.Round(time.Second / time.Duration(10))
+	}
+	return d
+}

--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -1,0 +1,55 @@
+package results
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/HdrHistogram/hdrhistogram-go"
+)
+
+type MergedResult struct {
+	Time                    time.Duration
+	Operations              int
+	ClusteringRows          int
+	OperationsPerSecond     float64
+	ClusteringRowsPerSecond float64
+	Errors                  int
+	Latency                 *hdrhistogram.Histogram
+}
+
+func NewMergedResult() *MergedResult {
+	result := &MergedResult{}
+	if globalResultConfiguration.measureLatency {
+		result.Latency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+	}
+	return result
+}
+
+func (mr *MergedResult) AddResult(result Result) {
+	mr.Time += result.ElapsedTime
+	mr.Operations += result.Operations
+	mr.ClusteringRows += result.ClusteringRows
+	mr.OperationsPerSecond += float64(result.Operations) / result.ElapsedTime.Seconds()
+	mr.ClusteringRowsPerSecond += float64(result.ClusteringRows) / result.ElapsedTime.Seconds()
+	mr.Errors += result.Errors
+	if globalResultConfiguration.measureLatency {
+		dropped := mr.Latency.Merge(result.Latency)
+		if dropped > 0 {
+			log.Print("dropped: ", dropped)
+		}
+	}
+}
+
+func (mr *MergedResult) PrintPartialResult() {
+	latencyError := ""
+	if globalResultConfiguration.measureLatency {
+		fmt.Printf(withLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors,
+			Round(time.Duration(mr.Latency.Max())), Round(time.Duration(mr.Latency.ValueAtQuantile(99.9))), Round(time.Duration(mr.Latency.ValueAtQuantile(99))),
+			Round(time.Duration(mr.Latency.ValueAtQuantile(95))), Round(time.Duration(mr.Latency.ValueAtQuantile(90))),
+			Round(time.Duration(mr.Latency.ValueAtQuantile(50))), Round(time.Duration(mr.Latency.Mean())),
+			latencyError)
+	} else {
+		fmt.Printf(withoutLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors)
+	}
+}

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -1,0 +1,73 @@
+package results
+
+import (
+	"time"
+
+	"github.com/HdrHistogram/hdrhistogram-go"
+)
+
+type histogramConfiguration struct {
+	minValue int64
+	maxValue int64
+	sigFig   int
+}
+
+type Configuration struct {
+	concurrency                   int
+	measureLatency                bool
+	latencyHistogramConfiguration histogramConfiguration
+}
+
+type Result struct {
+	Final          bool
+	ElapsedTime    time.Duration
+	Operations     int
+	ClusteringRows int
+	Errors         int
+	Latency        *hdrhistogram.Histogram
+}
+
+func SetGlobalHistogramConfiguration(minValue int64, maxValue int64, sigFig int) {
+	globalResultConfiguration.latencyHistogramConfiguration.minValue = minValue
+	globalResultConfiguration.latencyHistogramConfiguration.maxValue = maxValue
+	globalResultConfiguration.latencyHistogramConfiguration.sigFig = sigFig
+}
+
+func GetGlobalHistogramConfiguration() (int64, int64, int) {
+	return globalResultConfiguration.latencyHistogramConfiguration.minValue,
+		globalResultConfiguration.latencyHistogramConfiguration.maxValue,
+		globalResultConfiguration.latencyHistogramConfiguration.sigFig
+}
+
+func SetGlobalMeasureLatency(value bool) {
+	globalResultConfiguration.measureLatency = value
+}
+
+func GetGlobalMeasureLatency() bool {
+	return globalResultConfiguration.measureLatency
+}
+
+func SetGlobalConcurrency(value int) {
+	globalResultConfiguration.concurrency = value
+}
+
+func GetGlobalConcurrency() int {
+	return globalResultConfiguration.concurrency
+}
+
+func NewHistogram(config *histogramConfiguration) *hdrhistogram.Histogram {
+	return hdrhistogram.New(config.minValue, config.maxValue, config.sigFig)
+}
+
+var globalResultConfiguration Configuration
+
+func init() {
+	globalResultConfiguration = Configuration{
+		measureLatency: false,
+		latencyHistogramConfiguration: histogramConfiguration{
+			minValue: 0,
+			maxValue: 2 ^ 63 - 1,
+			sigFig:   3,
+		},
+	}
+}

--- a/pkg/results/thread_result.go
+++ b/pkg/results/thread_result.go
@@ -1,0 +1,74 @@
+package results
+
+import "time"
+
+type TestThreadResult struct {
+	FullResult    *Result
+	PartialResult *Result
+	ResultChannel chan Result
+	partialStart  time.Time
+}
+
+func NewTestThreadResult() *TestThreadResult {
+	r := &TestThreadResult{}
+	r.FullResult = &Result{}
+	r.PartialResult = &Result{}
+	r.FullResult.Final = true
+	if globalResultConfiguration.measureLatency {
+		r.FullResult.Latency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+		r.PartialResult.Latency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+	}
+	r.ResultChannel = make(chan Result, 1)
+	return r
+}
+
+func (r *TestThreadResult) IncOps() {
+	r.FullResult.Operations++
+	r.PartialResult.Operations++
+}
+
+func (r *TestThreadResult) IncRows() {
+	r.FullResult.ClusteringRows++
+	r.PartialResult.ClusteringRows++
+}
+
+func (r *TestThreadResult) AddRows(n int) {
+	r.FullResult.ClusteringRows += n
+	r.PartialResult.ClusteringRows += n
+}
+
+func (r *TestThreadResult) IncErrors() {
+	r.FullResult.Errors++
+	r.PartialResult.Errors++
+}
+
+func (r *TestThreadResult) ResetPartialResult() {
+	r.PartialResult = &Result{}
+	if globalResultConfiguration.measureLatency {
+		r.PartialResult.Latency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+	}
+}
+
+func (r *TestThreadResult) RecordLatency(start time.Time, end time.Time) {
+	value := end.Sub(start)
+	if r.FullResult.Latency != nil {
+		_ = r.FullResult.Latency.RecordValue(value.Nanoseconds())
+	}
+	if r.PartialResult.Latency != nil {
+		_ = r.PartialResult.Latency.RecordValue(value.Nanoseconds())
+	}
+}
+
+func (r *TestThreadResult) SubmitResult() {
+	now := time.Now()
+	if now.Sub(r.partialStart) > time.Second {
+		r.ResultChannel <- *r.PartialResult
+		r.ResetPartialResult()
+		r.partialStart = now
+	}
+
+}
+
+func (r *TestThreadResult) StopReporting() {
+	close(r.ResultChannel)
+}

--- a/pkg/results/thread_results.go
+++ b/pkg/results/thread_results.go
@@ -1,0 +1,81 @@
+package results
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	withLatencyLineFmt    = "\n%5v %7v %7v %6v %-6v %-6v %-6v %-6v %-6v %-6v %-6v %v"
+	withoutLatencyLineFmt = "\n%5v %7v %7v %6v"
+)
+
+type TestResults struct {
+	threadResults   []*TestThreadResult
+	numberOfThreads int
+	startTime       time.Time
+}
+
+func (tr *TestResults) Init(concurrency int) {
+	tr.threadResults = make([]*TestThreadResult, concurrency)
+	tr.numberOfThreads = concurrency
+	for i := range tr.threadResults {
+		tr.threadResults[i] = NewTestThreadResult()
+	}
+}
+
+func (tr *TestResults) SetStartTime() {
+	tr.startTime = time.Now()
+}
+
+func (tr *TestResults) GetTestResult(idx int) *TestThreadResult {
+	return tr.threadResults[idx]
+}
+
+func (tr *TestResults) GetTestResults() []*TestThreadResult {
+	return tr.threadResults
+}
+
+func (tr *TestResults) GetResultsFromThreadsAndMerge() (bool, *MergedResult) {
+	result := NewMergedResult()
+	final := false
+	for i, ch := range tr.threadResults {
+		res := <-ch.ResultChannel
+		if !final && res.Final {
+			final = true
+			result = NewMergedResult()
+			for _, ch2 := range tr.threadResults[0:i] {
+				res = <-ch2.ResultChannel
+				for !res.Final {
+					res = <-ch2.ResultChannel
+				}
+				result.AddResult(res)
+			}
+		} else if final && !res.Final {
+			for !res.Final {
+				res = <-ch.ResultChannel
+			}
+		}
+		result.AddResult(res)
+	}
+	result.Time /= time.Duration(globalResultConfiguration.concurrency)
+	return final, result
+}
+
+func (tr *TestResults) GetTotalResults() *MergedResult {
+	final, result := tr.GetResultsFromThreadsAndMerge()
+	for !final {
+		result.Time = time.Since(tr.startTime)
+		result.PrintPartialResult()
+		final, result = tr.GetResultsFromThreadsAndMerge()
+	}
+	return result
+}
+
+func (tr *TestResults) PrintResultsHeader() {
+	if globalResultConfiguration.measureLatency {
+		fmt.Printf(withLatencyLineFmt, "time", "ops/s", "rows/s", "errors", "max", "99.9th", "99th", "95th", "90th", "median", "mean", "")
+	} else {
+		fmt.Printf(withoutLatencyLineFmt, "time", "ops/s", "rows/s", "errors")
+	}
+}

--- a/pkg/workloads/workloads.go
+++ b/pkg/workloads/workloads.go
@@ -1,4 +1,4 @@
-package main
+package workloads
 
 import (
 	"log"
@@ -23,7 +23,7 @@ const (
 // Bounds are inclusive
 type TokenRange struct {
 	Start int64
-	End int64
+	End   int64
 }
 
 type WorkloadGenerator interface {
@@ -244,7 +244,7 @@ func (tsw *TimeSeriesRead) Restart() {
 
 type RangeScan struct {
 	TotalRangeCount int
-	RangeOffset	    int
+	RangeOffset     int
 	RangeCount      int
 	NextRange       int
 }
@@ -253,10 +253,10 @@ func NewRangeScan(totalRangeCount int, rangeOffset int, rangeCount int) *RangeSc
 	return &RangeScan{totalRangeCount, rangeOffset, rangeOffset + rangeCount, rangeOffset}
 }
 
-func (rs* RangeScan) NextTokenRange() TokenRange {
+func (rs *RangeScan) NextTokenRange() TokenRange {
 	// Special case, no range splitting
 	if rs.TotalRangeCount == 1 {
-		rs.NextRange++;
+		rs.NextRange++
 		return TokenRange{minToken, maxToken}
 	}
 
@@ -271,9 +271,9 @@ func (rs* RangeScan) NextTokenRange() TokenRange {
 	tokensPerRange := int64(tokenCount / uint64(rs.TotalRangeCount))
 
 	currentRange := rs.NextRange
-	rs.NextRange++;
+	rs.NextRange++
 
-	firstToken := minToken + int64(currentRange) * tokensPerRange
+	firstToken := minToken + int64(currentRange)*tokensPerRange
 	var lastToken int64
 	// Make sure the very last range streches all the way to maxToken.
 	if rs.NextRange == rs.TotalRangeCount {

--- a/pkg/workloads/workloads_test.go
+++ b/pkg/workloads/workloads_test.go
@@ -1,4 +1,4 @@
-package main
+package workloads
 
 import (
 	"fmt"
@@ -30,7 +30,7 @@ func TestSequentialWorkload(t *testing.T) {
 			expectedPk := tc.partitionOffset
 			expectedCk := int64(0)
 
-			for true {
+			for {
 				if wrkld.IsDone() && expectedPk < tc.partitionOffset+tc.partitionCount {
 					t.Errorf("got end of stream; expected %d", expectedPk)
 				}
@@ -66,10 +66,8 @@ func TestSequentialWorkload(t *testing.T) {
 					}
 					expectedCk = 0
 					expectedPk++
-				} else {
-					if wrkld.IsPartitionDone() {
-						t.Errorf("got end of partition; expected %d", expectedCk)
-					}
+				} else if wrkld.IsPartitionDone() {
+					t.Errorf("got end of partition; expected %d", expectedCk)
 				}
 			}
 		})


### PR DESCRIPTION
This fix is meant to prepare repo to get https://github.com/scylladb/scylla-bench/issues/49 fixed.
Done on top of https://github.com/scylladb/scylla-bench/pull/54

No functional changes, only moving code out of main package.
PR tested, no regression found