### PR TITLE
feature: add error-at-row-limit option

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ var (
 
 	mode        string
 	latencyType string
+	maxErrorsAtRow int
 	concurrency int
 	maximumRate int
 
@@ -265,6 +266,7 @@ func main() {
 	flag.StringVar(&clientKeyFile, "tls-client-key-file", "", "path to client key file, needed to enable client certificate authentication")
 
 	flag.StringVar(&hostSelectionPolicy, "host-selection-policy", "token-aware", "set the driver host selection policy (round-robin,token-aware,dc-aware),default 'token-aware'")
+	flag.IntVar(&maxErrorsAtRow, "error-at-row-limit", 0, "set limit of errors caught by one thread at row after which workflow will be terminated and error reported. Set it to 0 if you want to haven no limit")
 
 	flag.Parse()
 	counterTableName = "test_counters"
@@ -492,8 +494,9 @@ func main() {
 		GetMode(mode)(session, testResult, GetWorkload(workload, i, partitionOffset, mode, writeRate, distribution), rateLimiter)
 	})
 
-	testResult.PrintTotalResults(testResult.GetTotalResults())
-
+	testResult.GetTotalResults()
+	testResult.PrintTotalResults()
+	os.Exit(testResult.GetFinalStatus())
 }
 
 func newHostSelectionPolicy(policy string, hosts []string) (gocql.HostSelectionPolicy, error) {

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -37,8 +37,9 @@ type Result struct {
 	Operations     int
 	ClusteringRows int
 	Errors         int
+	CriticalErrors []error
 	RawLatency     *hdrhistogram.Histogram
-	CoFixedLatency     *hdrhistogram.Histogram
+	CoFixedLatency *hdrhistogram.Histogram
 }
 
 func SetGlobalHistogramConfiguration(minValue int64, maxValue int64, sigFig int) {

--- a/pkg/results/thread_result.go
+++ b/pkg/results/thread_result.go
@@ -9,6 +9,8 @@ type TestThreadResult struct {
 	partialStart  time.Time
 }
 
+var GlobalErrorFlag = false
+
 func NewTestThreadResult() *TestThreadResult {
 	r := &TestThreadResult{}
 	r.FullResult = &Result{}
@@ -43,6 +45,16 @@ func (r *TestThreadResult) IncErrors() {
 	r.FullResult.Errors++
 	r.PartialResult.Errors++
 }
+
+func (r *TestThreadResult) SubmitCriticalError(err error) {
+	if r.FullResult.CriticalErrors == nil {
+		r.FullResult.CriticalErrors = []error{err}
+	} else {
+		r.FullResult.CriticalErrors = append(r.FullResult.CriticalErrors, err)
+	}
+	GlobalErrorFlag = true
+}
+
 
 func (r *TestThreadResult) ResetPartialResult() {
 	r.PartialResult = &Result{}


### PR DESCRIPTION
-error-at-row-limit sets limit of errors after which thread stop executing command other threads to terminate and report error

fixes https://github.com/scylladb/scylla-bench/issues/59