### PR TITLE
readme: document the correct way to build shard-aware scylla-bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,24 @@ scylla-bench is a benchmarking tool for [Scylla](https://github.com/scylladb/scy
 
 ## Install
 
+The recommended way to install scylla-bench is to download the repository and then install it from source:
+
 ```
-go get github.com/scylladb/scylla-bench
+git clone https://github.com/scylladb/scylla-bench
+cd scylla-bench/
+go install .
 ```
+
+__It is not recommended to download and install the tool directly using `go get` or `go install`__.
+If you do that, a scylla-bench binary will be built __without using ScyllaDB's fork of the gocql driver__, and the shard-awareness __won't work__.
+
+```bash
+# If you use those commands, shard-awareness won't work!
+# go get github.com/scylladb/scylla-bench
+# go install github.com/scylladb/scylla-bench
+```
+
+This is due to the `go` tool not honoring replace directives in the `go.mod` file: https://github.com/golang/go/issues/30354
 
 ## Usage
 


### PR DESCRIPTION
Currently, README.md suggests using the `go get` command to download and
install scylla-bench. However, this method results in a scylla-bench
binary being built with the upstream version of the gocql driver, not
the ScyllaDB's fork - and the latter is required for the shard-awareness
to work.

Considering that scylla-bench was created for benchmarking Scylla, it
makes more sense to build it with our fork of gocql. This commit
improves the README.md: a correct way to build scylla-bench is now
included with an explanation why simply using `go get` does not work.

Fixes #70