### PR TITLE
main.go: add hdr-latency-file option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/scylladb/scylla-bench
 go 1.12
 
 require (
-	github.com/HdrHistogram/hdrhistogram-go v1.1.0 // indirect
+	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgRRqzCuPshRkQ7I=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
+github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=

--- a/main.go
+++ b/main.go
@@ -87,15 +87,13 @@ var (
 
 	// Any error response that comes with delay greater than errorToTimeoutCutoffTime
 	// to be considered as timeout error and recorded to histogram as such
-	errorToTimeoutCutoffTime    time.Duration
-
-	startTime time.Time
-
-	stopAll uint32
-
-	measureLatency bool
-	hdrLatencyFile string
-	validateData   bool
+	errorToTimeoutCutoffTime time.Duration
+	startTime                time.Time
+	stopAll                  uint32
+	measureLatency           bool
+	hdrLatencyFile  string
+	hdrLatencyUnits string
+	validateData    bool
 )
 
 func Query(session *gocql.Session, request string) {
@@ -246,6 +244,7 @@ func main() {
 
 	flag.BoolVar(&measureLatency, "measure-latency", true, "measure request latency")
 	flag.StringVar(&hdrLatencyFile, "hdr-latency-file", "", "log co-fixed and raw latency hdr histograms into a file")
+	flag.StringVar(&hdrLatencyUnits, "hdr-latency-units", "ns", "ns (nano seconds), us (microseconds), ms (milliseconds)")
 
 	flag.BoolVar(&validateData, "validate-data", false, "write meaningful data and validate while reading")
 
@@ -516,13 +515,14 @@ func newHostSelectionPolicy(policy string, hosts []string) (gocql.HostSelectionP
 }
 
 func setResultsConfiguration() {
-	results.SetGlobalHistogramConfiguration(
-		time.Microsecond.Nanoseconds()*50,
-		(timeout*3).Nanoseconds(),
-		3,
-	)
 	results.SetGlobalMeasureLatency(measureLatency)
 	results.SetGlobalHdrLatencyFile(hdrLatencyFile)
+	results.SetGlobalHdrLatencyUnits(hdrLatencyUnits)
+	results.SetGlobalHistogramConfiguration(
+		0,
+		(timeout*3).Nanoseconds(),
+		5,
+	)
 	results.SetGlobalConcurrency(concurrency)
 	results.SetGlobalLatencyTypeFromString(latencyType)
 }

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ var (
 	stopAll uint32
 
 	measureLatency bool
+	hdrLatencyFile string
 	validateData   bool
 )
 
@@ -244,6 +245,8 @@ func main() {
 	flag.Int64Var(&partitionOffset, "partition-offset", 0, "start of the partition range (only for sequential workload)")
 
 	flag.BoolVar(&measureLatency, "measure-latency", true, "measure request latency")
+	flag.StringVar(&hdrLatencyFile, "hdr-latency-file", "", "log co-fixed and raw latency hdr histograms into a file")
+
 	flag.BoolVar(&validateData, "validate-data", false, "write meaningful data and validate while reading")
 
 	var startTimestamp int64
@@ -519,6 +522,7 @@ func setResultsConfiguration() {
 		3,
 	)
 	results.SetGlobalMeasureLatency(measureLatency)
+	results.SetGlobalHdrLatencyFile(hdrLatencyFile)
 	results.SetGlobalConcurrency(concurrency)
 	results.SetGlobalLatencyTypeFromString(latencyType)
 }

--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -108,7 +108,7 @@ func (mr *MergedResult) getLatencyHistogram() *hdrhistogram.Histogram {
 	return mr.RawLatency
 }
 
-func (mr *MergedResult) SaveLatenciesToHdrHistogramLogFile(hdrLogWriter *hdrhistogram.HistogramLogWriter) {
+func (mr *MergedResult) SaveLatenciesToHdrHistogram(hdrLogWriter *hdrhistogram.HistogramLogWriter) {
 	startTimeMs := mr.HistogramStartTime / 1000000000
 	endTimeMs := time.Now().UnixNano() / 1000000000
 	mr.CoFixedLatency.SetStartTimeMs(startTimeMs)
@@ -126,11 +126,12 @@ func (mr *MergedResult) SaveLatenciesToHdrHistogramLogFile(hdrLogWriter *hdrhist
 func (mr *MergedResult) PrintPartialResult() {
 	latencyError := ""
 	if globalResultConfiguration.measureLatency {
+		scale := globalResultConfiguration.hdrLatencyScale
 		var latencyHist = mr.getLatencyHistogram()
 		fmt.Printf(withLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors,
-			Round(time.Duration(latencyHist.Max())), Round(time.Duration(latencyHist.ValueAtQuantile(99.9))), Round(time.Duration(latencyHist.ValueAtQuantile(99))),
-			Round(time.Duration(latencyHist.ValueAtQuantile(95))), Round(time.Duration(latencyHist.ValueAtQuantile(90))),
-			Round(time.Duration(latencyHist.ValueAtQuantile(50))), Round(time.Duration(latencyHist.Mean())),
+			Round(time.Duration(latencyHist.Max() * scale)), Round(time.Duration(latencyHist.ValueAtQuantile(99.9) * scale)), Round(time.Duration(latencyHist.ValueAtQuantile(99) * scale)),
+			Round(time.Duration(latencyHist.ValueAtQuantile(95) * scale)), Round(time.Duration(latencyHist.ValueAtQuantile(90) * scale)),
+			Round(time.Duration(latencyHist.ValueAtQuantile(50) * scale)), Round(time.Duration(latencyHist.Mean() * float64(scale))),
 			latencyError)
 	} else {
 		fmt.Printf(withoutLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors)

--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -3,6 +3,8 @@ package results
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
@@ -16,15 +18,17 @@ type MergedResult struct {
 	ClusteringRowsPerSecond float64
 	Errors                  int
 	CriticalErrors          []error
+	HistogramStartTime		int64
 	RawLatency              *hdrhistogram.Histogram
-	CoFixedLatency          *hdrhistogram.Histogram
+	CoFixedLatency 			*hdrhistogram.Histogram
 }
 
 func NewMergedResult() *MergedResult {
 	result := &MergedResult{}
 	if globalResultConfiguration.measureLatency {
-		result.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
-		result.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+		result.HistogramStartTime = time.Now().UnixNano()
+		result.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "raw")
+		result.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "co-fixed")
 	}
 	return result
 }
@@ -57,15 +61,72 @@ func (mr *MergedResult) AddResult(result Result) {
 	}
 }
 
+func InitHdrLogWriter(fileName string, baseTime int64) *hdrhistogram.HistogramLogWriter {
+	fileNameAbs, err := filepath.Abs(fileName)
+	if err != nil {
+		panic(err)
+	}
+	dirName := filepath.Dir(fileNameAbs)
+	err = os.MkdirAll(dirName, os.ModePerm)
+	if err != nil {
+		if ! os.IsExist(err) {
+			panic(err)
+		}
+	}
+
+	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+
+	writer := hdrhistogram.NewHistogramLogWriter(file)
+	if err = writer.OutputLogFormatVersion(); err != nil {
+		panic(err)
+	}
+
+	if err = writer.OutputComment("Logging op latencies for Cassandra Stress"); err != nil {
+		panic(err)
+	}
+	baseTimeMsec := baseTime / 1000000
+	writer.SetBaseTime(baseTimeMsec)
+	if err = writer.OutputBaseTime(baseTimeMsec); err != nil {
+		panic(err)
+	}
+	if err = writer.OutputStartTime(baseTimeMsec); err != nil {
+		panic(err)
+	}
+	if err = writer.OutputLegend(); err != nil {
+		panic(err)
+	}
+	return writer
+}
+
+func (mr *MergedResult) getLatencyHistogram() *hdrhistogram.Histogram {
+	if globalResultConfiguration.latencyTypeToPrint == LatencyTypeCoordinatedOmissionFixed {
+		return mr.CoFixedLatency
+	}
+	return mr.RawLatency
+}
+
+func (mr *MergedResult) SaveLatenciesToHdrHistogramLogFile(hdrLogWriter *hdrhistogram.HistogramLogWriter) {
+	startTimeMs := mr.HistogramStartTime / 1000000000
+	endTimeMs := time.Now().UnixNano() / 1000000000
+	mr.CoFixedLatency.SetStartTimeMs(startTimeMs)
+	mr.CoFixedLatency.SetEndTimeMs(endTimeMs)
+	if err := hdrLogWriter.OutputIntervalHistogram(mr.CoFixedLatency); err != nil {
+		fmt.Printf("Failed to write co-fixed hdr histogram: %s\n", err.Error())
+	}
+	mr.RawLatency.SetStartTimeMs(startTimeMs)
+	mr.RawLatency.SetEndTimeMs(endTimeMs)
+	if err := hdrLogWriter.OutputIntervalHistogram(mr.RawLatency); err != nil {
+		fmt.Printf("Failed to write raw hdr histogram: %s\n", err.Error())
+	}
+}
+
 func (mr *MergedResult) PrintPartialResult() {
 	latencyError := ""
 	if globalResultConfiguration.measureLatency {
-		var latencyHist *hdrhistogram.Histogram
-		if globalResultConfiguration.latencyTypeToPrint == LatencyTypeCoordinatedOmissionFixed {
-			latencyHist = mr.CoFixedLatency
-		} else {
-			latencyHist = mr.RawLatency
-		}
+		var latencyHist = mr.getLatencyHistogram()
 		fmt.Printf(withLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors,
 			Round(time.Duration(latencyHist.Max())), Round(time.Duration(latencyHist.ValueAtQuantile(99.9))), Round(time.Duration(latencyHist.ValueAtQuantile(99))),
 			Round(time.Duration(latencyHist.ValueAtQuantile(95))), Round(time.Duration(latencyHist.ValueAtQuantile(90))),

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -27,6 +27,7 @@ var LatencyTypes = map[string]int{
 type Configuration struct {
 	concurrency                   int
 	measureLatency                bool
+	hdrLatencyFile                string
 	latencyTypeToPrint            int
 	latencyHistogramConfiguration histogramConfiguration
 }
@@ -83,6 +84,10 @@ func GetGlobalMeasureLatency() bool {
 	return globalResultConfiguration.measureLatency
 }
 
+func SetGlobalHdrLatencyFile(value string) {
+	globalResultConfiguration.hdrLatencyFile = value
+}
+
 func SetGlobalConcurrency(value int) {
 	globalResultConfiguration.concurrency = value
 }
@@ -91,8 +96,10 @@ func GetGlobalConcurrency() int {
 	return globalResultConfiguration.concurrency
 }
 
-func NewHistogram(config *histogramConfiguration) *hdrhistogram.Histogram {
-	return hdrhistogram.New(config.minValue, config.maxValue, config.sigFig)
+func NewHistogram(config *histogramConfiguration, name string) *hdrhistogram.Histogram {
+	histogram := hdrhistogram.New(config.minValue, config.maxValue, config.sigFig)
+	histogram.SetTag(name)
+	return histogram
 }
 
 var globalResultConfiguration Configuration

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -28,6 +28,7 @@ type Configuration struct {
 	concurrency                   int
 	measureLatency                bool
 	hdrLatencyFile                string
+	hdrLatencyScale                int64
 	latencyTypeToPrint            int
 	latencyHistogramConfiguration histogramConfiguration
 }
@@ -44,8 +45,8 @@ type Result struct {
 }
 
 func SetGlobalHistogramConfiguration(minValue int64, maxValue int64, sigFig int) {
-	globalResultConfiguration.latencyHistogramConfiguration.minValue = minValue
-	globalResultConfiguration.latencyHistogramConfiguration.maxValue = maxValue
+	globalResultConfiguration.latencyHistogramConfiguration.minValue = minValue / globalResultConfiguration.hdrLatencyScale
+	globalResultConfiguration.latencyHistogramConfiguration.maxValue = maxValue / globalResultConfiguration.hdrLatencyScale
 	globalResultConfiguration.latencyHistogramConfiguration.sigFig = sigFig
 }
 
@@ -86,6 +87,22 @@ func GetGlobalMeasureLatency() bool {
 
 func SetGlobalHdrLatencyFile(value string) {
 	globalResultConfiguration.hdrLatencyFile = value
+}
+
+func SetGlobalHdrLatencyUnits(value string) {
+	switch value {
+	case "ns":
+		globalResultConfiguration.hdrLatencyScale = 1
+		break
+	case "us":
+		globalResultConfiguration.hdrLatencyScale = 1000
+		break
+	case "ms":
+		globalResultConfiguration.hdrLatencyScale = 1000000
+		break
+	default:
+		panic("Wrong value for hdr-latency-scale, only supported values are: ns, us and ms")
+	}
 }
 
 func SetGlobalConcurrency(value int) {

--- a/pkg/results/thread_result.go
+++ b/pkg/results/thread_result.go
@@ -17,10 +17,10 @@ func NewTestThreadResult() *TestThreadResult {
 	r.PartialResult = &Result{}
 	r.FullResult.Final = true
 	if globalResultConfiguration.measureLatency {
-		r.FullResult.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
-		r.FullResult.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
-		r.PartialResult.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
-		r.PartialResult.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+		r.FullResult.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "raw-latency")
+		r.FullResult.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "co-fixed-lantecy")
+		r.PartialResult.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "raw-latency")
+		r.PartialResult.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "co-fixed-lantecy")
 	}
 	r.ResultChannel = make(chan Result, 1)
 	return r
@@ -59,8 +59,8 @@ func (r *TestThreadResult) SubmitCriticalError(err error) {
 func (r *TestThreadResult) ResetPartialResult() {
 	r.PartialResult = &Result{}
 	if globalResultConfiguration.measureLatency {
-		r.PartialResult.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
-		r.PartialResult.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration)
+		r.PartialResult.RawLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "raw-latency")
+		r.PartialResult.CoFixedLatency = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "co-fixed-lantecy")
 	}
 }
 

--- a/pkg/results/thread_result.go
+++ b/pkg/results/thread_result.go
@@ -1,6 +1,8 @@
 package results
 
-import "time"
+import (
+	"time"
+)
 
 type TestThreadResult struct {
 	FullResult    *Result
@@ -68,12 +70,11 @@ func (r *TestThreadResult) RecordRawLatency(latency time.Duration) {
 	if ! globalResultConfiguration.measureLatency {
 		return
 	}
-	lv := latency.Nanoseconds()
+	lv := latency.Nanoseconds() / globalResultConfiguration.hdrLatencyScale
 
 	if lv >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
 		lv = globalResultConfiguration.latencyHistogramConfiguration.maxValue
 	}
-
 	_ = r.FullResult.RawLatency.RecordValue(lv)
 	_ = r.PartialResult.RawLatency.RecordValue(lv)
 }
@@ -82,7 +83,7 @@ func (r *TestThreadResult) RecordCoFixedLatency(latency time.Duration) {
 	if ! globalResultConfiguration.measureLatency {
 		return
 	}
-	lv := latency.Nanoseconds()
+	lv := latency.Nanoseconds() / globalResultConfiguration.hdrLatencyScale
 
 	if lv >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
 		lv = globalResultConfiguration.latencyHistogramConfiguration.maxValue

--- a/pkg/results/thread_results.go
+++ b/pkg/results/thread_results.go
@@ -86,7 +86,7 @@ func (tr *TestResults) GetTotalResults() {
 		result.Time = time.Since(tr.startTime)
 		result.PrintPartialResult()
 		if hdrLogWriter != nil {
-			result.SaveLatenciesToHdrHistogramLogFile(hdrLogWriter)
+			result.SaveLatenciesToHdrHistogram(hdrLogWriter)
 		}
 	}
 	tr.totalResult = result
@@ -118,13 +118,14 @@ func (tr *TestResults) PrintTotalResults() {
 }
 
 func printLatencyResults(name string, latency *hdrhistogram.Histogram) {
+	scale := globalResultConfiguration.hdrLatencyScale
 	fmt.Println(name, ":\n  max:\t\t", time.Duration(latency.Max()),
-		"\n  99.9th:\t", time.Duration(latency.ValueAtQuantile(99.9)),
-		"\n  99th:\t\t", time.Duration(latency.ValueAtQuantile(99)),
-		"\n  95th:\t\t", time.Duration(latency.ValueAtQuantile(95)),
-		"\n  90th:\t\t", time.Duration(latency.ValueAtQuantile(90)),
-		"\n  median:\t", time.Duration(latency.ValueAtQuantile(50)),
-		"\n  mean:\t\t", time.Duration(latency.Mean()))
+		"\n  99.9th:\t", time.Duration(latency.ValueAtQuantile(99.9) * scale),
+		"\n  99th:\t\t", time.Duration(latency.ValueAtQuantile(99) * scale),
+		"\n  95th:\t\t", time.Duration(latency.ValueAtQuantile(95) * scale),
+		"\n  90th:\t\t", time.Duration(latency.ValueAtQuantile(90) * scale),
+		"\n  median:\t", time.Duration(latency.ValueAtQuantile(50) * scale),
+		"\n  mean:\t\t", time.Duration(latency.Mean() * float64(scale)))
 }
 
 func (tr *TestResults) GetFinalStatus() int {


### PR DESCRIPTION
This option will make s-b to dump every reporting period (1s)
 hdr with latencies into a file
It write two types of latencies:
raw latency, tagged as raw
coordinated omission fixed latency, tagged as co-fixed