### PR TITLE
fix crash when running uniform workload with zero cluster size

### DIFF
--- a/pkg/workloads/workloads.go
+++ b/pkg/workloads/workloads.go
@@ -100,6 +100,9 @@ func (ru *RandomUniform) NextPartitionKey() int64 {
 }
 
 func (ru *RandomUniform) NextClusteringKey() int64 {
+	if ru.ClusteringRowCount == 0 {
+		return 0
+	}
 	return ru.Generator.Int63n(ru.ClusteringRowCount)
 }
 


### PR DESCRIPTION
Running a uniform workload with zero cluster size causes panic since `ru.Generator.Int63n(ru.ClusteringRowCount)` library function panics when input is zero. 