### PR TITLE
Fix hdr memory consumption

### DIFF
--- a/main.go
+++ b/main.go
@@ -511,8 +511,10 @@ func main() {
 		fmt.Println("Start timestamp:\t", startTime.UnixNano())
 		fmt.Println("Write rate:\t\t", int64(maximumRate)/partitionCount)
 	}
-
 	setResultsConfiguration()
+
+	fmt.Println("Hdr memory consumption:\t", results.GetHdrMemoryConsumption(concurrency), "bytes")
+
 	testResult := RunConcurrently(maximumRate, func(i int, testResult *results.TestThreadResult, rateLimiter RateLimiter) {
 		GetMode(mode)(session, testResult, GetWorkload(workload, i, partitionOffset, mode, writeRate, distribution), rateLimiter)
 	})
@@ -540,7 +542,7 @@ func setResultsConfiguration() {
 	results.SetGlobalHdrLatencyFile(hdrLatencyFile)
 	results.SetGlobalHdrLatencyUnits(hdrLatencyUnits)
 	results.SetGlobalHistogramConfiguration(
-		0,
+		time.Microsecond.Nanoseconds()*50,
 		(timeout * 3).Nanoseconds(),
 		5,
 	)

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -20,7 +20,7 @@ const (
 )
 
 var LatencyTypes = map[string]int{
-	"raw": LatencyTypeRaw,
+	"raw":                        LatencyTypeRaw,
 	"fixed-coordinated-omission": LatencyTypeCoordinatedOmissionFixed,
 }
 
@@ -28,7 +28,7 @@ type Configuration struct {
 	concurrency                   int
 	measureLatency                bool
 	hdrLatencyFile                string
-	hdrLatencyScale                int64
+	hdrLatencyScale               int64
 	latencyTypeToPrint            int
 	latencyHistogramConfiguration histogramConfiguration
 }
@@ -64,18 +64,17 @@ func GetGlobalLatencyType(latencyType int) {
 	globalResultConfiguration.latencyTypeToPrint = latencyType
 }
 
-func SetGlobalLatencyTypeFromString(latencyType string){
+func SetGlobalLatencyTypeFromString(latencyType string) {
 	SetGlobalLatencyType(LatencyTypes[latencyType])
 }
 
 func ValidateGlobalLatencyType(latencyType string) error {
 	_, ok := LatencyTypes[latencyType]
-	if ! ok {
+	if !ok {
 		return errors.New(fmt.Sprintf("unkown value %s, supported values are: raw, fixed-coordinated-omission", latencyType))
 	}
 	return nil
 }
-
 
 func SetGlobalMeasureLatency(value bool) {
 	globalResultConfiguration.measureLatency = value

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -120,6 +120,11 @@ func NewHistogram(config *histogramConfiguration, name string) *hdrhistogram.His
 
 var globalResultConfiguration Configuration
 
+func GetHdrMemoryConsumption(concurrency int) int {
+	hdr := NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, "example_hdr")
+	return hdr.ByteSize() * concurrency * 4
+}
+
 func init() {
 	globalResultConfiguration = Configuration{
 		measureLatency: false,


### PR DESCRIPTION
There is problem with HDR overuse memory.
It comes from setting lower limit to 0.
Fix it to be 50 microseconds and print consumption.