### PR TITLE
main.go: reduce sigFig's value to make RAM usage be sane

### DIFF
--- a/main.go
+++ b/main.go
@@ -546,7 +546,11 @@ func setResultsConfiguration() {
 	results.SetGlobalHistogramConfiguration(
 		time.Microsecond.Nanoseconds()*50,
 		(timeout * 3).Nanoseconds(),
-		5,
+		// TODO: make sigFig be configurable.
+		//       Do not make it be bigger than 4 by default
+		//       because RAM usage increases insanely with such numbers.
+		//       '3' must be enough in most of the cases.
+		3,
 	)
 	results.SetGlobalConcurrency(concurrency)
 	results.SetGlobalLatencyTypeFromString(latencyType)


### PR DESCRIPTION
Some time ago (https://github.com/scylladb/scylla-bench/pull/75) the sigFig value was changed from 3 to 5 which greatly
increased the RAM usage.

Comparison on the single machine and same command
with '3' and '5' values for it.

Value is set to '3':

```
 time   ops/s  rows/s errors max    99.9th 99th   95th   90th   median mean
   1s   50000   50000      0 12ms   5.2ms  2.8ms  1.2ms  983µs  754µs  821µs
   2s   50100   50100      0 12ms   8ms    2.4ms  1.3ms  983µs  754µs  829µs
   3s   50245   50245      0 11ms   6ms    2.3ms  1.2ms  983µs  786µs  822µs
   4s   50062   50062      0 9.3ms  5.9ms  2.4ms  1.6ms  1ms    786µs  837µs
   5s   50059   50059      0 9.3ms  5ms    2ms    1.1ms  950µs  786µs  800µs
   6s   50032   50032      0 6ms    4.4ms  2.2ms  1.5ms  983µs  786µs  818µs
   7s   49954   49954      0 12ms   6.2ms  2.5ms  1.5ms  1ms    786µs  841µs
   8s   50245   50245      0 13ms   5.6ms  2.2ms  1.2ms  983µs  786µs  815µs
```

And for '5':

```
 time   ops/s  rows/s errors max    99.9th 99th   95th   90th   median mean
 1.1s   49972   49972      0 53ms   16ms   2.1ms  1.2ms  1ms    754µs  841µs
 2.1s   50778   50778      0 48ms   20ms   3.8ms  1.6ms  1.1ms  786µs  911µs
 3.3s   49400   49400      0 217ms  95ms   3.6ms  1.7ms  1.2ms  786µs  1.1ms
 4.2s   55178   55178      0 200ms  86ms   7.4ms  1.7ms  1.1ms  786µs  1.2ms
 5.2s   50070   50070      0 7.8ms  4.1ms  2.8ms  1.5ms  1ms    786µs  835µs
 6.3s   47207   47207      0 51ms   20ms   7.4ms  2ms    1.4ms  786µs  1ms
 7.3s   49845   49845      0 63ms   35ms   13ms   2.8ms  1.5ms  786µs  1.3ms  Killed
```

In the case of '5' it gets OOMKilled all the time.

So, set it to be '3' for now.
Let's add an option in future if we need to redefine it.