### PR TITLE
use cluster.Keyspace before connecting to the nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -371,6 +371,8 @@ func main() {
 	cluster.NumConns = connectionCount
 	cluster.PageSize = pageSize
 	cluster.Timeout = timeout
+	cluster.Keyspace = keyspaceName
+
 	policy, err := newHostSelectionPolicy(hostSelectionPolicy, strings.Split(nodes, ","))
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Seem what's described in https://github.com/gocql/gocql/issues/1621 might be
affecting us, and making scylla-bench send unblanced
traffic to scylla

REF: https://github.com/gocql/gocql/issues/1621