### PR TITLE
fix: create 'scylla_bench' keyspace before it's usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -422,7 +422,6 @@ func main() {
 	cluster.NumConns = connectionCount
 	cluster.PageSize = pageSize
 	cluster.Timeout = timeout
-	cluster.Keyspace = keyspaceName
 
 	policy, err := newHostSelectionPolicy(hostSelectionPolicy, strings.Split(nodes, ","))
 	if err != nil {
@@ -508,13 +507,23 @@ func main() {
 		cluster.SslOpts = sslOpts
 	}
 
+	// Use separate session to create the keyspace which we will use in the main session
+	prepare_session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	PrepareDatabase(prepare_session, replicationFactor)
+	prepare_session.Close()
+
+	// NOTE: set the keyspace explicitly to workaround the following bug:
+	//       https://github.com/gocql/gocql/issues/1621
+	cluster.Keyspace = keyspaceName
+
 	session, err := cluster.CreateSession()
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer session.Close()
-
-	PrepareDatabase(session, replicationFactor)
 
 	interrupted := make(chan os.Signal, 1)
 	signal.Notify(interrupted, os.Interrupt)


### PR DESCRIPTION
In the PR [1] that was merged recently we started using keyspace in the config object, but the code with it's creation gets run after it's usage.

So, create the keyspace before it's usage to avoid failures on clusters which do not have when 'scylla-bench' gets used.

[1] https://github.com/scylladb/scylla-bench/pull/97