### PR TITLE
use InsecureSkipVerify correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -465,9 +465,10 @@ func main() {
 	if tlsEncryption {
 		sslOpts := &gocql.SslOptions{
 			Config: &tls.Config{
-				ServerName: serverName,
+				ServerName:         serverName,
+				InsecureSkipVerify: !hostVerification,
 			},
-			EnableHostVerification: hostVerification,
+			EnableHostVerification: false,
 		}
 
 		if caCertFile != "" {


### PR DESCRIPTION
Recent change to newer `scylladb/gocql==1.7.2` seem like by default new we have host verification when using TLS, we should be aligning the usage as https://github.com/scylladb/gocql/blob/master/conn.go#L103

Ref: https://github.com/scylladb/gocql/blob/master/scyllacloud/cluster.go#L62