### PR TITLE
fix: avoid getting panic in the '(mr *MergedResult) AddResult(...)'

### DIFF
--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -18,9 +18,9 @@ type MergedResult struct {
 	ClusteringRowsPerSecond float64
 	Errors                  int
 	CriticalErrors          []error
-	HistogramStartTime		int64
+	HistogramStartTime      int64
 	RawLatency              *hdrhistogram.Histogram
-	CoFixedLatency 			*hdrhistogram.Histogram
+	CoFixedLatency          *hdrhistogram.Histogram
 }
 
 func NewMergedResult() *MergedResult {
@@ -50,13 +50,17 @@ func (mr *MergedResult) AddResult(result Result) {
 		}
 	}
 	if globalResultConfiguration.measureLatency {
-		dropped := mr.RawLatency.Merge(result.RawLatency)
-		if dropped > 0 {
-			log.Print("dropped: ", dropped)
+		if result.RawLatency != nil {
+			dropped_raw := mr.RawLatency.Merge(result.RawLatency)
+			if dropped_raw > 0 {
+				log.Print("dropped: ", dropped_raw)
+			}
 		}
-		dropped = mr.CoFixedLatency.Merge(result.CoFixedLatency)
-		if dropped > 0 {
-			log.Print("dropped: ", dropped)
+		if result.CoFixedLatency != nil {
+			dropped_cofixed := mr.CoFixedLatency.Merge(result.CoFixedLatency)
+			if dropped_cofixed > 0 {
+				log.Print("dropped: ", dropped_cofixed)
+			}
 		}
 	}
 }
@@ -69,7 +73,7 @@ func InitHdrLogWriter(fileName string, baseTime int64) *hdrhistogram.HistogramLo
 	dirName := filepath.Dir(fileNameAbs)
 	err = os.MkdirAll(dirName, os.ModePerm)
 	if err != nil {
-		if ! os.IsExist(err) {
+		if !os.IsExist(err) {
 			panic(err)
 		}
 	}
@@ -129,9 +133,9 @@ func (mr *MergedResult) PrintPartialResult() {
 		scale := globalResultConfiguration.hdrLatencyScale
 		var latencyHist = mr.getLatencyHistogram()
 		fmt.Printf(withLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors,
-			Round(time.Duration(latencyHist.Max() * scale)), Round(time.Duration(latencyHist.ValueAtQuantile(99.9) * scale)), Round(time.Duration(latencyHist.ValueAtQuantile(99) * scale)),
-			Round(time.Duration(latencyHist.ValueAtQuantile(95) * scale)), Round(time.Duration(latencyHist.ValueAtQuantile(90) * scale)),
-			Round(time.Duration(latencyHist.ValueAtQuantile(50) * scale)), Round(time.Duration(latencyHist.Mean() * float64(scale))),
+			Round(time.Duration(latencyHist.Max()*scale)), Round(time.Duration(latencyHist.ValueAtQuantile(99.9)*scale)), Round(time.Duration(latencyHist.ValueAtQuantile(99)*scale)),
+			Round(time.Duration(latencyHist.ValueAtQuantile(95)*scale)), Round(time.Duration(latencyHist.ValueAtQuantile(90)*scale)),
+			Round(time.Duration(latencyHist.ValueAtQuantile(50)*scale)), Round(time.Duration(latencyHist.Mean()*float64(scale))),
 			latencyError)
 	} else {
 		fmt.Printf(withoutLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors)


### PR DESCRIPTION
Check for the nil-state of the 'result.RawLatency' attribute before processing it to avoid following panic:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x5fb33c]

    goroutine 1 [running]:
    github.com/HdrHistogram/hdrhistogram-go.(*iterator).next(0xc000171448)
        .../github.com/!hdr!histogram/hdrhistogram-go@v1.1.2/hdr.go:670 +0x1c
    github.com/HdrHistogram/hdrhistogram-go.(*rIterator).next(...)
        .../github.com/!hdr!histogram/hdrhistogram-go@v1.1.2/hdr.go:683
    github.com/HdrHistogram/hdrhistogram-go.(*Histogram).Merge(
            0xf0000000e?, 0x4000000000a?)
        .../github.com/!hdr!histogram/hdrhistogram-go@v1.1.2/hdr.go:177 +0x8d
    %s-b%/pkg/results.(*MergedResult).AddResult(
            0xc2abffef60, {0x0, 0x0, 0x0, 0x0, 0x0, {0x0, 0x0, 0x0}, 0x0, ...})
        .../pkg/results/merged_result.go:53 +0x1b0
    %s-b%/pkg/results.(*TestResults).GetResultsFromThreadsAndMerge(0xc000691380)
        .../pkg/results/thread_results.go:60 +0x89
    %s-b%/pkg/results.(*TestResults).GetTotalResults(0xc000691380)
        .../pkg/results/thread_results.go:82 +0xcc
    main.main()
        .../main.go:596 +0x355d