### PR TITLE
Add possibility to stop execution after specific number of errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ var (
 	mode           string
 	latencyType    string
 	maxErrorsAtRow int
+	maxErrors      int
 	concurrency    int
 	maximumRate    int
 
@@ -329,6 +330,11 @@ func main() {
 
 	flag.StringVar(&hostSelectionPolicy, "host-selection-policy", "token-aware", "set the driver host selection policy (round-robin,token-aware,dc-aware),default 'token-aware'")
 	flag.IntVar(&maxErrorsAtRow, "error-at-row-limit", 0, "set limit of errors caught by one thread at row after which workflow will be terminated and error reported. Set it to 0 if you want to haven no limit")
+	flag.IntVar(
+		&maxErrors,
+		"error-limit", 0,
+		"Number of errors in summary to appear before stopping the execution of a workflow. "+
+			"If it is set to '0' then no limit for number of errors is applied.")
 
 	flag.StringVar(&cloudConfigPath, "cloud-config-path", "", "set the cloud config bundle")
 
@@ -573,6 +579,16 @@ func main() {
 	fmt.Println("Mode:\t\t\t", mode)
 	fmt.Println("Workload:\t\t", workload)
 	fmt.Println("Timeout:\t\t", timeout)
+	if maxErrorsAtRow == 0 {
+		fmt.Println("Max error number at row: unlimited")
+	} else {
+		fmt.Println("Max error number at row:", maxErrorsAtRow)
+	}
+	if maxErrors == 0 {
+		fmt.Println("Max error number:\t unlimited")
+	} else {
+		fmt.Println("Max error number:\t", maxErrors)
+	}
 	fmt.Println("Retries:\t\t")
 	fmt.Println("  number:\t\t", retryPolicy.NumRetries)
 	fmt.Println("  min interval:\t\t", retryPolicy.Min)

--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -140,7 +140,7 @@ func (mr *MergedResult) PrintPartialResult() {
 
 func (mr *MergedResult) PrintCriticalErrors() {
 	if mr.CriticalErrors != nil {
-		fmt.Printf("\nFollowing critical errors where caught during the run:\n")
+		fmt.Printf("\nFollowing critical errors were caught during the run:\n")
 		for _, err := range mr.CriticalErrors {
 			fmt.Printf("    %s\n", err.Error())
 		}


### PR DESCRIPTION
Now it is possible to specify number of errors after which a stress runner will stop the execution.
To do it just add following cmd option to the s-b command: `-error-limit n`
If it is not set it gets default value as `0` which means `no limit` (status quo).