### PR TITLE
stop creating counter tables by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,11 +117,16 @@ func Query(session *gocql.Session, request string) {
 func PrepareDatabase(session *gocql.Session, replicationFactor int) {
 	Query(session, fmt.Sprintf("CREATE KEYSPACE IF NOT EXISTS %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : %d }", keyspaceName, replicationFactor))
 
-	Query(session, "CREATE TABLE IF NOT EXISTS "+keyspaceName+"."+tableName+" (pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck)) WITH compression = { }")
+	switch mode {
+		case "counter_update":
+			fallthrough
+		case "counter_read":
+			Query(session, "CREATE TABLE IF NOT EXISTS "+keyspaceName+"."+counterTableName+
+				" (pk bigint, ck bigint, c1 counter, c2 counter, c3 counter, c4 counter, c5 counter, PRIMARY KEY(pk, ck)) WITH compression = { }")
+		default:
+			Query(session, "CREATE TABLE IF NOT EXISTS "+keyspaceName+"."+tableName+" (pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck)) WITH compression = { }")
 
-	Query(session, "CREATE TABLE IF NOT EXISTS "+keyspaceName+"."+counterTableName+
-		" (pk bigint, ck bigint, c1 counter, c2 counter, c3 counter, c4 counter, c5 counter, PRIMARY KEY(pk, ck)) WITH compression = { }")
-
+	}
 	if validateData {
 		switch mode {
 		case "write":


### PR DESCRIPTION
when scylla-bench is used ontop of scylla with tablets enabled the following error is failing it:
```
2024/07/20 06:27:52 Cannot use the 'counter' type for table scylla_bench.test_counters: Counters are not yet supported with tablets
```

scylla-bench should stop creating counter table if not asked for `counter_read` or `counter_write` operations