### PR TITLE
Add logic to build image with custom gocql version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.21
+
+ARG version
+ARG fork
+ENV version=${version}
+ENV fork=${fork:-scylladb/scylla-bench}
+
+RUN apt-get update && apt-get -y install --no-install-recommends unzip curl && apt-get clean &&  rm -rf /var/lib/apt/lists/*
+
+RUN curl -Lo sb.zip https://github.com/${fork}/archive/refs/${version}.zip && \
+    unzip sb.zip && \
+    cd ./scylla-bench-* && \
+    GO111MODULE=on go install . && \
+    cd .. && \
+    rm -f sb.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Makefile
+
+# Default variables
+DOCKERFILE_PATH ?= Dockerfile
+SCYLLA_BENCH_VERSION ?= tags/v0.1.22
+GOCQL_REPO ?= github.com/scylladb/gocql
+
+build-image-with-custom-gocql-commit:
+	@echo "Replacing gocql with commit ID ${GOCQL_COMMIT_ID}"
+	go mod edit -replace github.com/gocql/gocql=${GOCQL_REPO}@${GOCQL_COMMIT_ID}
+	go mod tidy
+
+	@echo "Building Docker image with tag ${IMAGE_TAG}"
+	docker build -f ${DOCKERFILE_PATH} . -t ${IMAGE_TAG} --build-arg version=${SCYLLA_BENCH_VERSION}


### PR DESCRIPTION
As per @dkropachev request I moved logic with building image with custom gocql version to `scylla-bench` repo to be able to replace:
```
      - name: Replace gocql with the PR version
        run: |
          cd scylla-bench
          go mod edit -replace github.com/gocql/gocql=../gocql
          go mod tidy
      - name: Build and push Scylla-bench Docker Image
        run: |
          cd scylla-bench
          export SCYLLA_BENCH_VERSION=tags/v0.1.22
          export NAME="${{ github.event.pull_request.head.ref }}"
          export SCYLLA_BENCH_DOCKER_IMAGE=scylladb/gocql-extended-ci:scylla-bench-${NAME}
          docker build -f ../gocql/.github/workflows/Dockerfile . -t ${SCYLLA_BENCH_DOCKER_IMAGE} --build-arg version=$SCYLLA_BENCH_VERSION
          docker push ${SCYLLA_BENCH_DOCKER_IMAGE}
 ```
 with 
 ```
       - name: Build and push scylla-bench image
        run: |
           cd scylla-bench
           GOCQL_REPO="${{ github.event.pull_request.head.repo.full_name }}" GOCQL_COMMIT_ID="${{ github.event.pull_request.head.ref }}" IMAGE_TAG="scylladb/gocql-extended-ci:scylla-bench-${GOCQL_COMMIT_ID}" make build-image-with-custom-gocql-commit
           docker push "scylladb/gocql-extended-ci:scylla-bench-${GOCQL_COMMIT_ID}"
   ```

in `gocql` extended CI
https://github.com/scylladb/gocql/pull/260#discussion_r1758729250