### PR TITLE
fix(host-verification): switch to gocql builtin hostname verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"log"
@@ -257,7 +256,6 @@ func main() {
 		caCertFile        string
 		clientCertFile    string
 		clientKeyFile     string
-		serverName        string
 		hostVerification  bool
 		clientCompression bool
 		connectionCount   int
@@ -336,7 +334,6 @@ func main() {
 	flag.StringVar(&password, "password", "", "cql password for authentication")
 
 	flag.BoolVar(&tlsEncryption, "tls", false, "use TLS encryption")
-	flag.StringVar(&serverName, "tls-server-name", "", "TLS server hostname")
 	flag.BoolVar(&hostVerification, "tls-host-verification", false, "verify server certificate")
 	flag.StringVar(&caCertFile, "tls-ca-cert-file", "", "path to CA certificate file, needed to enable encryption")
 	flag.StringVar(&clientCertFile, "tls-client-cert-file", "", "path to client certificate file, needed to enable client certificate authentication")
@@ -507,11 +504,7 @@ func main() {
 
 	if tlsEncryption {
 		sslOpts := &gocql.SslOptions{
-			Config: &tls.Config{
-				ServerName:         serverName,
-				InsecureSkipVerify: !hostVerification,
-			},
-			EnableHostVerification: false,
+			EnableHostVerification: hostVerification,
 		}
 
 		if caCertFile != "" {
@@ -540,12 +533,6 @@ func main() {
 		}
 		if clientCertFile != "" && clientKeyFile == "" {
 			log.Fatal("tls-client-key-file is required when tls-client-cert-file is provided")
-		}
-
-		if hostVerification {
-			if serverName == "" {
-				log.Fatal("tls-server-name is required when tls-host-verification is enabled")
-			}
 		}
 
 		cluster.SslOpts = sslOpts


### PR DESCRIPTION
Custom logic of providing server name as a separate scylla-bench parameter, for host verification, was introduced a few years ago.
But now host verification is performed by default by the driver itself, when TLS encryption is enabled and gocql.SslOptions.EnableHostVerification flag is set.

The change switches to default host verification mechanism and removes the corresponding customization from the scylla-bench.

Fixes: https://github.com/scylladb/scylla-bench/issues/140