### PR TITLE
Add extended version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 GOCQL_REPO?=github.com/scylladb/gocql
 DOCKER_IMAGE_TAG?=scylla-bench
 
+VERSION ?= $(shell git describe --tags 2>/dev/null || echo "dev")
+COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS_VERSION := -X github.com/scylladb/scylla-bench/internal/version.version=$(VERSION) -X github.com/scylladb/scylla-bench/internal/version.commit=$(COMMIT) -X github.com/scylladb/scylla-bench/internal/version.date=$(BUILD_DATE)
+
 _prepare_build_dir:
 	@mkdir build >/dev/null 2>&1 || true
 
@@ -12,16 +17,16 @@ _use-custom-gocql-version:
   	fi;\
   	echo "Using custom gocql commit \"${GOCQL_VERSION}\"";\
 	go mod edit -replace "github.com/gocql/gocql=${GOCQL_REPO}@${GOCQL_VERSION}";\
-	go mod tidy;\
+	go mod tidy -compat=1.17;\
 	}
 
 build: _prepare_build_dir
 	@echo "Building static scylla-bench"
-	@CGO_ENABLED=0 go build -ldflags="-s -w" -o ./build/scylla-bench .
+	@CGO_ENABLED=0 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o ./build/scylla-bench .
 
 build-debug: _prepare_build_dir
 	@echo "Building debug version of static scylla-bench"
-	@CGO_ENABLED=0 go build -gcflags "all=-N -l" -o ./build/scylla-bench .
+	@CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags="$(LDFLAGS_VERSION)" -o ./build/scylla-bench .
 
 .PHONY: build-with-custom-gocql-version
 build-with-custom-gocql-version: _use-custom-gocql-version build

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,362 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const (
+	gocqlPackage     = "github.com/gocql/gocql"
+	githubTimeout    = 5 * time.Second
+	userAgent        = "scylla-bench (github.com/scylladb/scylla-bench)"
+	githubAPIBaseURL = "https://api.github.com"
+)
+
+// Default version values; can be overridden via ldflags
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+type ComponentInfo struct {
+	Version    string `json:"version"`
+	CommitDate string `json:"commit_date"`
+	CommitSHA  string `json:"commit_sha"`
+}
+
+type VersionInfo struct {
+	ScyllaBench ComponentInfo `json:"scylla-bench"`
+	Driver      ComponentInfo `json:"scylla-driver"`
+}
+
+type githubRelease struct {
+	TagName   string    `json:"tag_name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type githubTag struct {
+	Object struct {
+		SHA string `json:"sha"`
+	} `json:"object"`
+}
+
+type githubClient struct {
+	client    *http.Client
+	baseURL   string
+	userAgent string
+}
+
+func newGithubClient() *githubClient {
+	return &githubClient{
+		client:    &http.Client{Timeout: githubTimeout},
+		baseURL:   githubAPIBaseURL,
+		userAgent: userAgent,
+	}
+}
+
+// Performs an HTTP GET request and decodes the JSON response to the target
+func (g *githubClient) getJSON(path string, target interface{}) error {
+	url := g.baseURL + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", g.userAgent)
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return fmt.Errorf("failed to decode JSON: %w", err)
+	}
+	return nil
+}
+
+// Fetches release date and commit SHA for the given version
+func (g *githubClient) getReleaseInfo(owner, repo, version string) (date, sha string, err error) {
+	// Fetch releases
+	path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
+	var releases []githubRelease
+	if err := g.getJSON(path, &releases); err != nil {
+		return "", "", fmt.Errorf("failed to fetch releases: %w", err)
+	}
+
+	// Find matching release
+	cleanVersion := strings.TrimPrefix(version, "v")
+	var releaseDate, tagName string
+	for _, release := range releases {
+		if strings.TrimPrefix(release.TagName, "v") == cleanVersion {
+			releaseDate, tagName = release.CreatedAt.Format(time.RFC3339), release.TagName
+			break
+		}
+	}
+	if tagName == "" {
+		return "", "", fmt.Errorf("release %s not found", version)
+	}
+
+	// Fetch tag info to get the commit SHA
+	tagPath := fmt.Sprintf("/repos/%s/%s/git/refs/tags/%s", owner, repo, tagName)
+	var tag githubTag
+	if err := g.getJSON(tagPath, &tag); err != nil {
+		return releaseDate, "", fmt.Errorf("failed to fetch tag info: %w", err)
+	}
+
+	return releaseDate, tag.Object.SHA, nil
+}
+
+// Fetches information about the given commit
+func (g *githubClient) getCommitInfo(owner, repo, sha string) (date string, err error) {
+	path := fmt.Sprintf("/repos/%s/%s/commits/%s", owner, repo, sha)
+	var commit struct {
+		Commit struct {
+			Committer struct {
+				Date string `json:"date"`
+			} `json:"committer"`
+		} `json:"commit"`
+	}
+
+	if err := g.getJSON(path, &commit); err != nil {
+		return "", fmt.Errorf("failed to fetch commit info: %w", err)
+	}
+
+	return commit.Commit.Committer.Date, nil
+}
+
+func tryGitCommand(args ...string) (string, bool) {
+	output, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(output)), true
+}
+
+// Reads version info from local Git repository
+func getGitVersionInfo() (ver, sha, buildDate string, ok bool) {
+	// Check if git is available and we're in a git repo
+	if _, ok := tryGitCommand("rev-parse", "--is-inside-work-tree"); !ok {
+		return "", "", "", false
+	}
+
+	// Get released version details
+	sha, ok = tryGitCommand("rev-parse", "HEAD")
+	if !ok {
+		return "", "", "", false
+	}
+	buildDate, ok = tryGitCommand("log", "-1", "--format=%cd", "--date=format:%Y-%m-%dT%H:%M:%SZ")
+	if !ok {
+		return "", "", "", false
+	}
+	if tags, ok := tryGitCommand("tag", "--points-at", "HEAD"); ok && tags != "" {
+		for _, tag := range strings.Split(tags, "\n") {
+			if strings.HasPrefix(tag, "v") {
+				return tag, sha, buildDate, true
+			}
+		}
+	}
+
+	// If not a released version, use the most recent tag to build a dev version string
+	if closestTag, ok := tryGitCommand("describe", "--tags", "--abbrev=0"); ok && strings.HasPrefix(closestTag, "v") {
+		return fmt.Sprintf("%s-dev-%s", closestTag, sha[:8]), sha, buildDate, true
+	}
+
+	return fmt.Sprintf("dev-%s", sha[:8]), sha, buildDate, true
+}
+
+func isCommitSHA(s string) bool {
+	shaPattern := regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+	return shaPattern.MatchString(s)
+}
+
+func extractCommitSHA(version string) string {
+	if isCommitSHA(version) {
+		return version
+	}
+
+	// If version is in pseudo-version format (e.g v0.0.0-20230101120000-abcdef123456)
+	if strings.Count(version, "-") >= 2 {
+		parts := strings.Split(version, "-")
+		candidate := parts[len(parts)-1]
+		if isCommitSHA(candidate) {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+func extractRepoOwner(repoPath string, defaultOwner string) string {
+	parts := strings.Split(repoPath, "/")
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return defaultOwner
+}
+
+// Extracts driver version info
+func getDriverVersionInfo() ComponentInfo {
+	info := ComponentInfo{
+		Version:    "unknown",
+		CommitSHA:  "unknown",
+		CommitDate: "unknown",
+	}
+
+	// Get driver module from build info
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
+	}
+	var driverModule *debug.Module
+	for _, dep := range buildInfo.Deps {
+		if dep.Path == gocqlPackage {
+			driverModule = dep
+			break
+		}
+	}
+	if driverModule == nil {
+		return info
+	}
+
+	github := newGithubClient()
+	if replacement := driverModule.Replace; replacement != nil {
+		// If custom version is set via GOCQL_VERSION env var
+		if envSHA := os.Getenv("GOCQL_VERSION"); envSHA != "" && isCommitSHA(envSHA) {
+			info.Version = envSHA
+			info.CommitSHA = envSHA
+
+			repoOwner := extractRepoOwner(os.Getenv("GOCQL_REPO"), "scylladb")
+			if date, err := github.getCommitInfo(repoOwner, "gocql", envSHA); err == nil {
+				info.CommitDate = date
+			}
+			return info
+		}
+
+		// Otherwise try to extract released version (e.g. v1.2.3)
+		if strings.HasPrefix(replacement.Version, "v") && !strings.Contains(replacement.Version, "-") {
+			info.Version = replacement.Version
+			if date, sha, err := github.getReleaseInfo("scylladb", "gocql", replacement.Version); err == nil {
+				info.CommitDate = date
+				info.CommitSHA = sha
+			}
+			return info
+		}
+
+		// Otherwise handle pseudo-versions or direct SHA
+		version := replacement.Version
+		if sha := extractCommitSHA(version); sha != "" {
+			info.Version = sha
+			info.CommitSHA = sha
+
+			repoOwner := extractRepoOwner(replacement.Path, "scylladb")
+			if date, err := github.getCommitInfo(repoOwner, "gocql", sha); err == nil {
+				info.CommitDate = date
+			}
+			return info
+		}
+
+		// As a fallback, just use what we have as a version
+		info.Version = version
+		return info
+	}
+
+	// If no driver module replacement, this is the upstream gocql driver
+	info.Version = driverModule.Version
+	info.CommitSHA = "upstream release"
+	return info
+}
+
+// Extracts build settings from debug.BuildInfo to be compatible with different Go versions, as
+// in older Go versions (pre 1.18), BuildInfo doesn't have Settings field
+func getBuildInfoSettings(info *debug.BuildInfo) (map[string]string, bool) {
+	settings := make(map[string]string)
+	// For Go 1.17 return an empty map
+	return settings, false
+}
+
+// Extracts scylla-bench version info
+func getMainBuildInfo() (ver, sha, buildDate string) {
+	ver, sha, buildDate = version, commit, date
+
+	// Use git info if no version was provided via ldflags
+	if ver == "dev" {
+		if gitVer, gitSha, gitDate, ok := getGitVersionInfo(); ok {
+			return gitVer, gitSha, gitDate
+		}
+	}
+
+	// Otherwise fall back to go build info
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if ver == "dev" {
+			if info.Main.Version != "" {
+				ver = info.Main.Version
+			} else {
+				ver = "(devel)"
+			}
+		}
+
+		// Try to get VCS information from build info settings
+		if settings, ok := getBuildInfoSettings(info); ok {
+			if vcsRev, ok := settings["vcs.revision"]; ok && sha == "unknown" {
+				sha = vcsRev
+			}
+			if vcsTime, ok := settings["vcs.time"]; ok && buildDate == "unknown" {
+				buildDate = vcsTime
+			}
+		}
+	}
+	return
+}
+
+// GetVersionInfo returns the version info for scylla-bench and scylla-gocql-driver
+func GetVersionInfo() VersionInfo {
+	ver, sha, buildDate := getMainBuildInfo()
+	return VersionInfo{
+		ScyllaBench: ComponentInfo{
+			Version:    ver,
+			CommitDate: buildDate,
+			CommitSHA:  sha,
+		},
+		Driver: getDriverVersionInfo(),
+	}
+}
+
+// FormatHuman returns a human-readable string with version info
+func (v VersionInfo) FormatHuman() string {
+	return fmt.Sprintf(`scylla-bench:
+    version: %s
+    commit sha: %s
+    commit date: %s
+scylla-gocql-driver:
+    version: %s
+    commit sha: %s
+    commit date: %s`,
+		v.ScyllaBench.Version,
+		v.ScyllaBench.CommitSHA,
+		v.ScyllaBench.CommitDate,
+		v.Driver.Version,
+		v.Driver.CommitSHA,
+		v.Driver.CommitDate)
+}
+
+// FormatJSON returns a JSON-formatted string with version info
+func (v VersionInfo) FormatJSON() (string, error) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal version info to JSON: %w", err)
+	}
+	return string(data), nil
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,186 @@
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetVersionInfo(t *testing.T) {
+	info := GetVersionInfo()
+	if info.ScyllaBench.Version == "" {
+		t.Error("ScyllaBench version should not be empty")
+	}
+	if info.Driver.Version == "" {
+		t.Error("Driver version should not be empty")
+	}
+}
+
+func TestVersionInfoFormatHuman(t *testing.T) {
+	info := VersionInfo{
+		ScyllaBench: ComponentInfo{
+			Version:    "v1.0.0",
+			CommitSHA:  "abcdef123456",
+			CommitDate: "2023-01-01T00:00:00Z",
+		},
+		Driver: ComponentInfo{
+			Version:    "v2.0.0",
+			CommitSHA:  "987654abcdef",
+			CommitDate: "2023-02-02T00:00:00Z",
+		},
+	}
+
+	humanOutput := info.FormatHuman()
+	expectedSubstrings := []string{
+		"scylla-bench:",
+		"version: v1.0.0",
+		"commit sha: abcdef123456",
+		"commit date: 2023-01-01T00:00:00Z",
+		"scylla-gocql-driver:",
+		"version: v2.0.0",
+		"commit sha: 987654abcdef",
+		"commit date: 2023-02-02T00:00:00Z",
+	}
+	for _, substr := range expectedSubstrings {
+		if !strings.Contains(humanOutput, substr) {
+			t.Errorf("Expected human output to contain '%s'. Actual output: %s", substr, humanOutput)
+		}
+	}
+}
+
+func TestVersionInfoFormatJSON(t *testing.T) {
+	info := VersionInfo{
+		ScyllaBench: ComponentInfo{
+			Version:    "v1.0.0",
+			CommitSHA:  "abcdef123456",
+			CommitDate: "2023-01-01T00:00:00Z",
+		},
+		Driver: ComponentInfo{
+			Version:    "v2.0.0",
+			CommitSHA:  "987654abcdef",
+			CommitDate: "2023-02-02T00:00:00Z",
+		},
+	}
+
+	jsonOutput, err := info.FormatJSON()
+	if err != nil {
+		t.Fatalf("FormatJSON() returned error: %v", err)
+	}
+
+	var parsed VersionInfo
+	if err := json.Unmarshal([]byte(jsonOutput), &parsed); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	if parsed.ScyllaBench.Version != "v1.0.0" {
+		t.Errorf("Expected ScyllaBench version '%s', got '%s'", info.ScyllaBench.Version, parsed.ScyllaBench.Version)
+	}
+	if parsed.Driver.CommitSHA != "987654abcdef" {
+		t.Errorf("Expected Driver commit SHA '%s', got '%s'", info.Driver.CommitSHA, parsed.Driver.CommitSHA)
+	}
+}
+
+func TestExtractCommitSHA(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"1234567", "1234567"},
+		{"v0.0.0-20230101120000-abcdef123456", "abcdef123456"},
+		{"v1.2.3", ""},
+		{"", ""},
+	}
+
+	for _, tc := range testCases {
+		result := extractCommitSHA(tc.input)
+		if result != tc.expected {
+			t.Errorf("extractCommitSHA(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestGithubClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("User-Agent") != userAgent {
+			t.Errorf("Expected User-Agent header %q, got %q", userAgent, r.Header.Get("User-Agent"))
+		}
+
+		// Mock responses based on the path
+		switch r.URL.Path {
+		case "/repos/testowner/testrepo/releases":
+			w.Write([]byte(`[
+				{
+					"tag_name": "v1.0.0",
+					"created_at": "2023-01-01T00:00:00Z"
+				}
+			]`))
+		case "/repos/testowner/testrepo/git/refs/tags/v1.0.0":
+			w.Write([]byte(`{
+				"object": {
+					"sha": "abcdef123456"
+				}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := &githubClient{
+		client:    &http.Client{},
+		baseURL:   server.URL,
+		userAgent: userAgent,
+	}
+
+	date, sha, err := client.getReleaseInfo("testowner", "testrepo", "1.0.0")
+	if err != nil {
+		t.Fatalf("getReleaseInfo() returned error: %v", err)
+	}
+	if date != "2023-01-01T00:00:00Z" {
+		t.Errorf("Expected date '2023-01-01T00:00:00Z', got '%s'", date)
+	}
+	if sha != "abcdef123456" {
+		t.Errorf("Expected SHA 'abcdef123456', got '%s'", sha)
+	}
+}
+
+func TestExtractRepoOwner(t *testing.T) {
+	testCases := []struct {
+		repoPath      string
+		defaultOwner  string
+		expectedOwner string
+	}{
+		{"github.com/scylladb/gocql", "default", "scylladb"},
+		{"example.com/owner/repo", "default", "owner"},
+		{"invalid", "default", "default"},
+		{"", "default", "default"},
+	}
+
+	for _, tc := range testCases {
+		result := extractRepoOwner(tc.repoPath, tc.defaultOwner)
+		if result != tc.expectedOwner {
+			t.Errorf("extractRepoOwner(%q, %q) = %q, expected %q",
+				tc.repoPath, tc.defaultOwner, result, tc.expectedOwner)
+		}
+	}
+}
+
+func TestGetDriverVersionWithEnvVar(t *testing.T) {
+	originalRepo := os.Getenv("GOCQL_REPO")
+	originalVersion := os.Getenv("GOCQL_VERSION")
+	defer func() {
+		os.Setenv("GOCQL_REPO", originalRepo)
+		os.Setenv("GOCQL_VERSION", originalVersion)
+	}()
+
+	os.Setenv("GOCQL_REPO", "github.com/testowner/gocql")
+	os.Setenv("GOCQL_VERSION", "1234567890abcdef")
+
+	info := getDriverVersionInfo()
+	if info.Version == "" {
+		t.Error("Driver version should not be empty")
+	}
+}


### PR DESCRIPTION
This change introduces 2 new CLI options to report the versions of scylla-bench and scylla-gocql-driver:
- `-version` for printing the versions info in human readable format
- `-version-json` for printing the versions info in JSOn format

For both scylla-bench and driver version the layered approach of extracting informaion is used
- scylla-bench version info is initially read from vars set via ldflags, if those were explicitly provided. Otherwise it falls back to getting VCS info from build info.
- driver version info in the 1st place is read from env. vars, if those were explicitly provided. Otherwise it tries to read the released version info. Then it tries to parse pseudo-version format, if version has it. Then it falls back to raw version string. 

Example of the new CLI options results:
```
❯ ./scylla-bench -version
scylla-bench:
    version: v0.1.24-dev-438fcfe2
    commit sha: 438fcfe2d336f23a5fa931910a60f14c3e099641
    commit date: 2025-02-25T17:50:57Z
scylla-gocql-driver:
    version: v1.14.4
    commit sha: 2be0988d03e67a530c29c9cae13ddac47358a45a
    commit date: 2024-09-19T11:47:32Z
❯ ./scylla-bench -version-json
{
  "scylla-bench": {
    "version": "v0.1.24-dev-438fcfe2",
    "commit_date": "2025-02-25T17:50:57Z",
    "commit_sha": "438fcfe2d336f23a5fa931910a60f14c3e099641"
  },
  "scylla-driver": {
    "version": "v1.14.4",
    "commit_date": "2024-09-19T11:47:32Z",
    "commit_sha": "2be0988d03e67a530c29c9cae13ddac47358a45a"
  }
}
```