### PR TITLE
Fix panic in DoWrite

### DIFF
--- a/modes.go
+++ b/modes.go
@@ -382,6 +382,7 @@ func DoWrites(session *gocql.Session, threadResult *results.TestThreadResult, wo
 		if err != nil {
 			panic(err)
 		}
+		bound := query.Bind(pk, ck, value)
 
 		currentAttempts := 0
 		// NOTE: use custom query string instead of 'query.String()' to avoid huge values printings
@@ -391,7 +392,7 @@ func DoWrites(session *gocql.Session, threadResult *results.TestThreadResult, wo
 			query.GetConsistency())
 		for {
 			requestStart := time.Now()
-			err = query.Exec()
+			err = bound.Exec()
 			requestEnd := time.Now()
 
 			if err == nil {


### PR DESCRIPTION
Regression since 016b539f
query.Bind is not performed which leads to panic:
```
panic: runtime error: index out of range [0] with length 0
github.com/gocql/gocql.createRoutingKey(0xc0002a0000, {0x0, 0x0, 0x0})
	/home/dmitry.kropachev/go/pkg/mod/github.com/scylladb/gocql@v1.14.6-0.20250502134006-32ec722fb53b/session.go:2294 +0x67f
github.com/gocql/gocql.(*Query).GetRoutingKey(0xc0003a8500)
```

Fixes: https://github.com/scylladb/scylla-bench/issues/185