### PR TITLE
fix(usage): usage should be printed on stdout not stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -285,6 +285,11 @@ func main() {
 		showJSONVersion bool
 	)
 
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stdout, "Usage:\n%s [options]\n\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
 	flag.StringVar(&mode, "mode", "", "operating mode: write, read, counter_update, counter_read, scan")
 	flag.StringVar(&workload, "workload", "", "workload: sequential, uniform, timeseries")
 	flag.StringVar(&consistencyLevel, "consistency-level", "quorum", "consistency level")
@@ -371,10 +376,6 @@ func main() {
 	flag.Parse()
 	counterTableName = "test_counters"
 
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stdout, "Usage:\n%s [options]\n\n", os.Args[0])
-		flag.PrintDefaults()
-	}
 
 	if showVersion || showJSONVersion {
 		info := version.GetVersionInfo()


### PR DESCRIPTION
In go's `flags` package, the default output for `usage` is to `stderr`, while in all other tools, usage was printed to `stdout`. Even thou `s-b` has the code for it, it is in the wrong place (after `flag.Parse`) which makes it default to printing to `stderr`.

This is just the move of `flag.Usage` to the begining of the `main` function so that `s-b` is uniformaly printing to `stdout` as all other tools are.

Caught in SCT by @juliayakovlev